### PR TITLE
Update README to include links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,40 +35,39 @@ If you enjoy using this extension
 
 ## Snippets
 
-- Filters
-  - Array
-  - Cart
-  - Collection
-  - Color
-  - Customer
-  - Default
-  - Font
-  - Format
-  - Hosted file
-  - HTML
-  - Localization
-  - Math
-  - Media
-  - Metafield
-  - Money
-  - Payment
-  - String
-  - Tag
-- Schema
+- [Filters](https://shopify.dev/docs/api/liquid/filters)
+  - [Array](https://shopify.dev/docs/api/liquid/filters/array-filters)
+  - [Cart](https://shopify.dev/docs/api/liquid/filters/cart-filters)
+  - [Collection](https://shopify.dev/docs/api/liquid/filters/collection-filters)
+  - [Color](https://shopify.dev/docs/api/liquid/filters/color-filters)
+  - [Customer](https://shopify.dev/docs/api/liquid/filters/customer-filters)
+  - [Default](https://shopify.dev/docs/api/liquid/filters/default-filters)
+  - [Font](https://shopify.dev/docs/api/liquid/filters/font-filters)
+  - [Format](https://shopify.dev/docs/api/liquid/filters/format-filters)
+  - [Hosted file](https://shopify.dev/docs/api/liquid/filters/hosted_file-filters)
+  - [HTML](https://shopify.dev/docs/api/liquid/filters/html-filters)
+  - [Localization](https://shopify.dev/docs/api/liquid/filters/localization-filters)
+  - [Math](https://shopify.dev/docs/api/liquid/filters/math-filters)
+  - [Media](https://shopify.dev/docs/api/liquid/filters/media-filters)
+  - [Metafield](https://shopify.dev/docs/api/liquid/filters/metafield-filters)
+  - [Money](https://shopify.dev/docs/api/liquid/filters/money-filters)
+  - [Payment](https://shopify.dev/docs/api/liquid/filters/payment-filters)
+  - [String](https://shopify.dev/docs/api/liquid/filters/string-filters)
+  - [Tag](https://shopify.dev/docs/api/liquid/filters/tag-filters)
 
+- [Schema](https://shopify.dev/docs/themes/architecture/settings)
   - Content
-  - Input settings
-  - Sidebar settings
+  - [Input settings](https://shopify.dev/docs/themes/architecture/settings/input-settings)
+  - [Sidebar settings](https://shopify.dev/docs/themes/architecture/settings/sidebar-settings)
 
-- Tags
-  - Conditional
-  - HTML
-  - Iteration
-  - Syntax
-  - Theme
-  - Variable
+- [Tags](https://shopify.dev/docs/api/liquid/tags)
+  - [Conditional](https://shopify.dev/docs/api/liquid/tags/conditional-tags)
+  - [HTML](https://shopify.dev/docs/api/liquid/tags/html-tags)
+  - [Iteration](https://shopify.dev/docs/api/liquid/tags/iteration-tags)
+  - [Syntax](https://shopify.dev/docs/api/liquid/tags/syntax-tags)
+  - [Theme](https://shopify.dev/docs/api/liquid/tags/theme-tags)
+  - [Variable](https://shopify.dev/docs/api/liquid/tags/variable-tags)
 
 ## Plans
 
 - Only suggest schema settings inside schema tag
-- Add markdown documentation with links to the official Shopify docs

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ If you enjoy using this extension
 ## Plans
 
 - Only suggest schema settings inside schema tag
+- Add markdown documentation with links to the official Shopify docs


### PR DESCRIPTION
Saw in the README that this was planned, but I went ahead and added it myself.
Not sure what `Content` is though.